### PR TITLE
FSD-717 - Harshal - Add ingress for artemis to access management console

### DIFF
--- a/stable/activemq-artemis/Chart.yaml
+++ b/stable/activemq-artemis/Chart.yaml
@@ -1,5 +1,5 @@
 name: activemq-artemis
-version: 0.3.7
+version: 0.3.8
 appVersion: 2.16.3
 description: a multi-protocol, embeddable, very high performance, clustered, asynchronous messaging system.
 keywords:

--- a/stable/activemq-artemis/templates/ci-ingress.yaml
+++ b/stable/activemq-artemis/templates/ci-ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    kubernetes.io/ingress.class: internal-ingress
+  name: {{ include "artemis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  rules:
+    - host: {{ include "artemis.fullname" . }}.ci.tarabutgateway.io
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "artemis.fullname" . }}
+                port:
+                  number: 8161
+  tls:
+    - hosts:
+        - {{ include "artemis.fullname" . }}.ci.tarabutgateway.io
+      secretName: {{ .Release.Namespace }}-{{ include "artemis.fullname" . }}-tls-cert

--- a/stable/activemq-artemis/templates/ci-ingress.yaml
+++ b/stable/activemq-artemis/templates/ci-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   rules:
-    - host: {{ include "artemis.fullname" . }}.ci.tarabutgateway.io
+    - host: {{ include "artemis.fullname" . }}.{{ .Values.environment }}.tarabutgateway.io
       http:
         paths:
           - path: /
@@ -23,5 +23,5 @@ spec:
                   number: 8161
   tls:
     - hosts:
-        - {{ include "artemis.fullname" . }}.ci.tarabutgateway.io
+        - {{ include "artemis.fullname" . }}.{{ .Values.environment }}.tarabutgateway.io
       secretName: {{ .Release.Namespace }}-{{ include "artemis.fullname" . }}-tls-cert

--- a/stable/activemq-artemis/templates/ingress.yaml
+++ b/stable/activemq-artemis/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   rules:
-    - host: {{ include "artemis.fullname" . }}.{{ .Values.environment }}.tarabutgateway.io
+    - host: {{ .Values.dashboardUrl }}
       http:
         paths:
           - path: /
@@ -23,5 +23,5 @@ spec:
                   number: 8161
   tls:
     - hosts:
-        - {{ include "artemis.fullname" . }}.{{ .Values.environment }}.tarabutgateway.io
+        - {{ .Values.dashboardUrl }}
       secretName: {{ .Release.Namespace }}-{{ include "artemis.fullname" . }}-tls-cert

--- a/stable/activemq-artemis/values.yaml
+++ b/stable/activemq-artemis/values.yaml
@@ -129,3 +129,4 @@ prometheus:
       selector:
         prometheus: kube-prometheus
 
+environment: {}

--- a/stable/activemq-artemis/values.yaml
+++ b/stable/activemq-artemis/values.yaml
@@ -129,4 +129,4 @@ prometheus:
       selector:
         prometheus: kube-prometheus
 
-environment: {}
+dashboardUrl: artemis.tarabutgateway.io


### PR DESCRIPTION
We need to test the workflow by adding an ingress to allow access for artemis management console. Once the workflow is tested, we will templetize for other higher environments.